### PR TITLE
Update example to be on V3

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,38 +42,26 @@ const encryptDecryptString = async () => {
     ];
 
     // 1. Encryption
-    // <Blob> encryptedString
-    // <Uint8Array(32)> symmetricKey 
-    const { encryptedString, symmetricKey } = await LitJsSdk.encryptString(messageToEncrypt);
-
-    // 2. Saving the Encrypted Content to the Lit Nodes
-    // <Unit8Array> encryptedSymmetricKey
-    const encryptedSymmetricKey = await litNodeClient.saveEncryptionKey({
-        accessControlConditions,
-        symmetricKey,
+    const { ciphertext, dataToEncryptHash} = await LitJsSdk.encryptString({
         authSig,
-        chain,
-    });
+        accessControlConditions,
+        dataToEncrypt: messageToEncrypt,
+        chain: 'ethereum',
+    }, litNodeClient);
 
     // 3. Decrypt it
-    // <String> toDecrypt
-    const toDecrypt = LitJsSdk.uint8arrayToString(encryptedSymmetricKey, 'base16');
-
-    // <Uint8Array(32)> _symmetricKey 
-    const _symmetricKey = await litNodeClient.getEncryptionKey({
-        accessControlConditions,
-        toDecrypt,
-        chain,
-        authSig
-    })
-
     // <String> decryptedString
     let decryptedString;
 
     try{
         decryptedString = await LitJsSdk.decryptString(
-            encryptedString,
-            _symmetricKey
+            {
+            authSig,
+            accessControlConditions,
+            ciphertext,
+            dataToEncryptHash,
+            chain: 'ethereum',
+            }, litNodeClient
         );
     }catch(e){
         console.log(e);
@@ -90,7 +78,7 @@ const signAuthMessage = async () => {
 
     // Replace this with you private key
     const privKey =
-    "3dfb4f70b15b6fccc786347aaea445f439a7f10fd10c55dd50cafc3d5a0abac1";
+    "";
     const privKeyBuffer = u8a.fromString(privKey, "base16");
     const wallet = new ethers.Wallet(privKeyBuffer);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "dev": "node main.js"
   },
   "dependencies": {
-    "@lit-protocol/lit-node-client": "^2.2.24",
+    "@lit-protocol/lit-node-client": "^3.0.6",
     "ethers": "^5.6.9",
     "siwe": "^1.1.6",
     "uint8arrays": "^3.0.0"


### PR DESCRIPTION
Running a few issues with getting this fully set up, but should be about ready for us to update this example

```
/Users/debbie_1/Documents/GitHub/lit-demo-simple-string-encrypt-nodejs/node_modules/@lit-protocol/encryption/src/lib/utils.js:11
    for (const token of expression) {
                        ^

TypeError: expression is not iterable
    at isValidBooleanExpression (/Users/debbie_1/Documents/GitHub/lit-demo-simple-string-encrypt-nodejs/node_modules/@lit-protocol/encryption/src/lib/utils.js:11:25)
    at AccessControlConditionsValidator.validate (/Users/debbie_1/Documents/GitHub/lit-demo-simple-string-encrypt-nodejs/node_modules/@lit-protocol/encryption/src/lib/params-validators.js:336:77)
    at safeParams (/Users/debbie_1/Documents/GitHub/lit-demo-simple-string-encrypt-nodejs/node_modules/@lit-protocol/encryption/src/lib/params-validators.js:19:46)
    at Object.encryptString (/Users/debbie_1/Documents/GitHub/lit-demo-simple-string-encrypt-nodejs/node_modules/@lit-protocol/encryption/src/lib/encryption.js:176:61)
    at encryptDecryptString (file:///Users/debbie_1/Documents/GitHub/lit-demo-simple-string-encrypt-nodejs/main.js:45:61)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

```